### PR TITLE
Mesos fix

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -215,14 +215,15 @@ sub-env $BIN_DIR/steps/collectstatic
 
 
 # Create .profile script for application runtime environment variables.
-set-env PATH '$HOME/.heroku/python/bin:$PATH'
+set-env BASE_PATH '$(cd `dirname $BASH_SOURCE`; pwd -P)'
+set-env PATH '$BASE_PATH/.heroku/python/bin:$PATH'
 set-env PYTHONUNBUFFERED true
-set-env PYTHONHOME /app/.heroku/python
-set-env LIBRARY_PATH '/app/.heroku/vendor/lib:/app/.heroku/python/lib:$LIBRARY_PATH'
-set-env LD_LIBRARY_PATH '/app/.heroku/vendor/lib:/app/.heroku/python/lib:$LD_LIBRARY_PATH'
+set-env PYTHONHOME '$BASE_PATH/.heroku/python'
+set-env LIBRARY_PATH '$BASE_PATH/.heroku/vendor/lib:$BASE_PATH/.heroku/python/lib:$LIBRARY_PATH'
+set-env LD_LIBRARY_PATH '$BASE_PATH/.heroku/vendor/lib:$BASE_PATH/.heroku/python/lib:$LD_LIBRARY_PATH'
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random
-set-default-env PYTHONPATH /app/
+set-default-env PYTHONPATH '$BASE_PATH'
 
 # Install sane-default script for $WEB_CONCURRENCY and $FORWARDED_ALLOW_IPS.
 cp $ROOT_DIR/vendor/python.gunicorn.sh $GUNICORN_PROFILE_PATH
@@ -267,4 +268,3 @@ if [[ ! "$DOCKER_BUILD" ]]; then
   bpwatch stop anvil_appdir_commit
   bpwatch stop compile
 fi
-

--- a/bin/compile
+++ b/bin/compile
@@ -213,6 +213,8 @@ source $BIN_DIR/steps/pip-install
 # Django collectstatic support.
 sub-env $BIN_DIR/steps/collectstatic
 
+# Update python shebang on the installed executables
+source $BIN_DIR/steps/update-py-shebang
 
 # Create .profile script for application runtime environment variables.
 set-env BASE_PATH '$(cd `dirname $BASH_SOURCE`; pwd -P)/../'

--- a/bin/compile
+++ b/bin/compile
@@ -215,7 +215,7 @@ sub-env $BIN_DIR/steps/collectstatic
 
 
 # Create .profile script for application runtime environment variables.
-set-env BASE_PATH '$(cd `dirname $BASH_SOURCE`; pwd -P)'
+set-env BASE_PATH '$(cd `dirname $BASH_SOURCE`; pwd -P)/../'
 set-env PATH '$BASE_PATH/.heroku/python/bin:$PATH'
 set-env PYTHONUNBUFFERED true
 set-env PYTHONHOME '$BASE_PATH/.heroku/python'

--- a/bin/steps/update-py-shebang
+++ b/bin/steps/update-py-shebang
@@ -1,0 +1,9 @@
+# Update python shebang location to pick it from env instead of full path
+puts-cmd "Update python shebang inside .heroku/python/bin/ files"
+
+set -e
+sed -i 's/#!\/app\/.heroku\/python\/bin\/python/#!\/usr\/bin\/env python/' .heroku/python/bin/*
+
+show-warnings
+
+echo


### PR DESCRIPTION
The scripts generated under `.profile.d/` directory had all the PATHs hardcoded to `/app/` as the application root. While that's the case on heroku, on mesos we need to always act with respect to our CWD.

Also when installing certain modules from pip, they create an executable python files like `gunicorn`. The problem is they've the `python` interpreter in their shebang hardcoded to fullpath as `/app/.heroku/python/bin/python`. I've added another step in the compile process to change them as well. 
